### PR TITLE
Drop loop kwarg from async_timeout.timeout

### DIFF
--- a/pytautulli/decorator.py
+++ b/pytautulli/decorator.py
@@ -39,9 +39,7 @@ def api_command(
 
             LOGGER.debug("Requesting %s", client.redact_string(url))
             try:
-                async with async_timeout.timeout(
-                    client._request_timeout, loop=asyncio.get_event_loop()
-                ):
+                async with async_timeout.timeout(client._request_timeout):
                     request = await client._session.request(
                         method=method.value,
                         url=url,


### PR DESCRIPTION
- async_timeout 4.0.0 drops the loop= kwarg and will fail if its passed